### PR TITLE
Implement hot reload on preview server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ init-toolkit:
 
 .PHONY: init-preview
 init-preview:
-	cd $(PREVIEW_DIR) && $(NPM) install && $(NPM) run build
+	cd $(PREVIEW_DIR) && $(NPM) install
 
 .PHONY: test-sample
 test-sample:
@@ -61,4 +61,4 @@ clean:
 .PHONY: serve
 serve:
 	$(MAKE) generate
-	cd $(PREVIEW_DIR) && $(NPM) run start
+	cd $(PREVIEW_DIR) && $(NPM) run dev

--- a/README.md
+++ b/README.md
@@ -32,10 +32,19 @@ XMLの検証やJSONの生成、プレビューサーバに関わるtoolkitの展
 6. Pull Requestを出す
    - CIが全て通る かつ 一人以上の人間から記事に対して `approve`　のレビューがつけばmergeして良し
 
-このほかに、記事をプレビューするための`make serve`が利用可能です。
+このほかに、記事をプレビューするための`make serve`が利用可能です。([Make Serveについて](#make-serveについて)を参照してください。)
 
 ### 構文を変更する
 1. `feature/{feature-name}` branchを切ってcheckoutする
 2. `schema.xsd`を変更する。
 XSDについては[この辺り](https://www.mlab.im.dendai.ac.jp/~yamada/web/xml/xmlschema.html)が日本語文書として有用かもしれません。
 3. 既存の文書のテストを通す `make test`
+
+### make serveについて
+-  `make serve`は、記事をプレビューするために利用できます
+- アプリ上にこの通りに描画される保証はありませんが、テキストスタイリング(太字や斜体、強調など)やメディア(YouTube, 画像)がうまく挿入されることを確認するのに利用できます。
+- `make serve`コマンドを実行すると、localhostにサーバが起動します。これは、`Ctrl+C`で終了できます
+- サーバを起動したまま記事(XML)を編集して、`make generate`コマンドを打つと、新しい記事の内容で再読み込みされます(Hot reload)
+
+
+

--- a/preview/rollup.config.js
+++ b/preview/rollup.config.js
@@ -73,7 +73,7 @@ export default {
 		// Watch the `public` directory and refresh the
 		// browser on changes when not in production
 		!production && livereload('public'),
-
+		!production && livereload('../generated'),
 		// If we're building for production (npm run build
 		// instead of npm run dev), minify
 		production && terser()


### PR DESCRIPTION
- Fix rollup configuration to watch `generated`
- Update `make serve` to use `development` mode (`npm run dev`)
- Insert some explanation about `make serve` at `README.md`