### PR TITLE
Bugfix: Error after reloading preview

### DIFF
--- a/preview/package.json
+++ b/preview/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "start": "sirv public --no-clear",
+    "start": "sirv public --no-clear --dev",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "clean": "rm -rf public/build",
     "clean:hard":"npm run clean && rm -rf node_modules"

--- a/preview/rollup.config.js
+++ b/preview/rollup.config.js
@@ -73,7 +73,6 @@ export default {
 		// Watch the `public` directory and refresh the
 		// browser on changes when not in production
 		!production && livereload('public'),
-		!production && livereload('../generated'),
 		// If we're building for production (npm run build
 		// instead of npm run dev), minify
 		production && terser()

--- a/preview/src/App.svelte
+++ b/preview/src/App.svelte
@@ -46,7 +46,7 @@
  {/each}
 
 	{:catch error}
-	 <p>An error occurred!</p>
+	 <p>An error occurred! {error}</p>
 	{/await}
 	</div>
 </section>


### PR DESCRIPTION
## Cause of errors
- The error was due to the cache problem
  - The content JSON was cached and it was not reloaded

## Solution
- Use sirv `--dev` flag to disable cache  

## Additional fixes
- Remove `generated` from tracking directory on `rollup`
- Display error kind if promise rejected